### PR TITLE
Fix broken builds on Node.js 12.x due to changes to the V8 API.

### DIFF
--- a/uwp/windows.devices.bluetooth.advertisement/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth.advertisement/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.advertisement/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.devices.bluetooth.advertisement/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth.advertisement/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.devices.bluetooth.advertisement/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth.advertisement/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -1074,7 +1073,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       try 
       {
         
-        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
 
         wrapper->_instance->LocalName = winRtValue;
       }
@@ -2641,7 +2640,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -2763,7 +2762,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -2793,12 +2792,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"received", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"stopped", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -4259,7 +4258,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -4324,7 +4323,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -4354,12 +4353,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"statusChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.devices.bluetooth.genericattributeprofile/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth.genericattributeprofile/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -1263,7 +1262,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSharingMode arg1 = static_cast<::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSharingMode>(Nan::To<int32_t>(info[1]).FromMaybe(0));
           
           op = ::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService::FromIdAsync(arg0,arg1);
@@ -1279,7 +1278,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Bluetooth::GenericAttributeProfile::GattDeviceService::FromIdAsync(arg0);
         }
@@ -2916,7 +2915,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -3038,7 +3037,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -3068,12 +3067,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"maxPduSizeChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"sessionStatusChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -4632,7 +4631,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -4697,7 +4696,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -4727,12 +4726,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"valueChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -11234,7 +11233,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       try 
       {
         
-        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
 
         wrapper->_instance->UserDescription = winRtValue;
       }
@@ -12728,7 +12727,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -12793,7 +12792,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -12823,12 +12822,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"advertisementStatusChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -14006,7 +14005,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -14185,7 +14184,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -14215,12 +14214,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"readRequested", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"subscribedClientsChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"writeRequested", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -14790,7 +14789,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -14912,7 +14911,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -14942,12 +14941,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"readRequested", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"writeRequested", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -15237,7 +15236,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -15302,7 +15301,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -15332,12 +15331,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"maxNotificationSizeChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -16591,7 +16590,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -16656,7 +16655,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -16686,12 +16685,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"stateChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -17308,7 +17307,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -17373,7 +17372,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -17403,12 +17402,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"stateChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 

--- a/uwp/windows.devices.bluetooth/CollectionsWrap.h
+++ b/uwp/windows.devices.bluetooth/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
+++ b/uwp/windows.devices.bluetooth/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.devices.bluetooth/OpaqueWrapper.h
+++ b/uwp/windows.devices.bluetooth/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.devices.bluetooth/_nodert_generated.cpp
+++ b/uwp/windows.devices.bluetooth/_nodert_generated.cpp
@@ -36,7 +36,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -516,7 +515,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Bluetooth::BluetoothAdapter::FromIdAsync(arg0);
         }
@@ -1854,7 +1853,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Bluetooth::BluetoothDevice::FromIdAsync(arg0);
         }
@@ -2136,7 +2135,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothDevice::GetDeviceSelectorFromDeviceName(arg0);
@@ -2509,7 +2508,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -2688,7 +2687,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -2718,12 +2717,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"nameChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"sdpRecordsChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -5325,7 +5324,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Bluetooth::BluetoothLEDevice::FromIdAsync(arg0);
         }
@@ -5451,7 +5450,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           Platform::String^ result;
           result = ::Windows::Devices::Bluetooth::BluetoothLEDevice::GetDeviceSelectorFromDeviceName(arg0);
@@ -5810,7 +5809,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -5989,7 +5988,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -6019,12 +6018,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Bluetooth {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"connectionStatusChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"gattServicesChanged", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"nameChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 

--- a/uwp/windows.devices.enumeration/CollectionsWrap.h
+++ b/uwp/windows.devices.enumeration/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.devices.enumeration/NodeRtUtils.cpp
+++ b/uwp/windows.devices.enumeration/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.devices.enumeration/OpaqueWrapper.h
+++ b/uwp/windows.devices.enumeration/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.devices.enumeration/_nodert_generated.cpp
+++ b/uwp/windows.devices.enumeration/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -765,7 +764,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       try 
       {
         
-        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+        Platform::String^ winRtValue = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
 
         wrapper->_instance->Title = winRtValue;
       }
@@ -1717,7 +1716,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               return value->IsString();
             },
             [](Local<Value> value) -> ::Platform::String^ {
-              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
             }
           ));
         return;
@@ -2128,7 +2127,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         try
         {
           ::Windows::Devices::Enumeration::DeviceInformation^ arg0 = UnwrapDeviceInformation(info[0]);
-          Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[1])));
+          Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[1])));
           ::Windows::Devices::Enumeration::DevicePickerDisplayStatusOptions arg2 = static_cast<::Windows::Devices::Enumeration::DevicePickerDisplayStatusOptions>(Nan::To<int32_t>(info[2]).FromMaybe(0));
           
           wrapper->_instance->SetDisplayStatus(arg0, arg1, arg2);
@@ -2219,7 +2218,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               return value->IsString();
             },
             [](Local<Value> value) -> ::Platform::String^ {
-              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
             }
           ));
         return;
@@ -2243,7 +2242,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -2422,7 +2421,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -2452,12 +2451,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"devicePickerDismissed", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"deviceSelected", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"disconnectButtonClicked", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -3771,7 +3770,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               return value->IsString();
             },
             [](Local<Value> value) -> ::Platform::String^ {
-              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
             },
             [](::Platform::Object^ val) -> Local<Value> {
               return CreateOpaqueWrapper(val);
@@ -4430,7 +4429,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -4723,7 +4722,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -4753,12 +4752,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"added", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"enumerationCompleted", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"removed", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"stopped", str)) &&(!NodeRT::Utils::CaseInsenstiveEquals(L"updated", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -5249,7 +5248,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5260,7 +5259,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5284,7 +5283,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Enumeration::DeviceInformation::CreateFromIdAsync(arg0);
         }
@@ -5300,7 +5299,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5311,7 +5310,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5399,7 +5398,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5410,7 +5409,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5461,7 +5460,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(arg0);
         }
@@ -5477,7 +5476,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5488,7 +5487,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5596,7 +5595,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5607,7 +5606,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5667,7 +5666,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           ::Windows::Devices::Enumeration::DeviceWatcher^ result;
           result = ::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(arg0);
@@ -5686,7 +5685,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           ::Windows::Foundation::Collections::IIterable<::Platform::String^>^ arg1 = 
             [] (v8::Local<v8::Value> value) -> ::Windows::Foundation::Collections::IIterable<::Platform::String^>^
             {
@@ -5697,7 +5696,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -5867,7 +5866,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
               return value->IsString();
             },
             [](Local<Value> value) -> ::Platform::String^ {
-              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
             },
             [](::Platform::Object^ val) -> Local<Value> {
               return CreateOpaqueWrapper(val);
@@ -6717,7 +6716,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           wrapper->_instance->Accept(arg0);
           return;   
@@ -7153,7 +7152,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -7218,7 +7217,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -7248,12 +7247,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"pairingRequested", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -8204,7 +8203,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           ::Windows::Devices::Enumeration::DeviceAccessInformation^ result;
           result = ::Windows::Devices::Enumeration::DeviceAccessInformation::CreateFromId(arg0);
@@ -8316,7 +8315,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -8381,7 +8380,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -8411,12 +8410,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Enumeration
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"accessChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 

--- a/uwp/windows.devices.radios/CollectionsWrap.h
+++ b/uwp/windows.devices.radios/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.devices.radios/NodeRtUtils.cpp
+++ b/uwp/windows.devices.radios/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.devices.radios/OpaqueWrapper.h
+++ b/uwp/windows.devices.radios/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.devices.radios/_nodert_generated.cpp
+++ b/uwp/windows.devices.radios/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -448,7 +447,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           op = ::Windows::Devices::Radios::Radio::FromIdAsync(arg0);
         }
@@ -694,7 +693,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -759,7 +758,7 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -789,12 +788,12 @@ namespace NodeRT { namespace Windows { namespace Devices { namespace Radios {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"stateChanged", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 

--- a/uwp/windows.foundation/CollectionsWrap.h
+++ b/uwp/windows.foundation/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.foundation/NodeRtUtils.cpp
+++ b/uwp/windows.foundation/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.foundation/OpaqueWrapper.h
+++ b/uwp/windows.foundation/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.foundation/_nodert_generated.cpp
+++ b/uwp/windows.foundation/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -765,7 +764,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           ::Platform::Object^ result;
           result = ::Windows::Foundation::PropertyValue::CreateString(arg0);
@@ -1505,7 +1504,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
                    return (!NodeRT::Utils::IsWinRtWrapper(value));
                  },
                  [](Local<Value> value) -> ::Platform::String^ {
-                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+                   return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
                  }
                 );
               }
@@ -3088,7 +3087,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
 		return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
       
       Local<Function> callback = info[1].As<Function>();
@@ -3153,7 +3152,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       }
       else 
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
 		return;
       }
 
@@ -3183,12 +3182,12 @@ namespace NodeRT { namespace Windows { namespace Foundation {
         return;
       }
 
-      String::Value eventName(info[0]);
+      String::Value eventName(v8::Isolate::GetCurrent(), info[0]);
       auto str = *eventName;
 
       if ((!NodeRT::Utils::CaseInsenstiveEquals(L"closed", str)))
       {
-        Nan::ThrowError(Nan::Error(String::Concat(NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
+        Nan::ThrowError(Nan::Error(String::Concat(v8::Isolate::GetCurrent(), NodeRT::Utils::NewString(L"given event name isn't supported: "), info[0].As<String>())));
         return;
       }
 
@@ -3824,7 +3823,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           winRtInstance = ref new ::Windows::Foundation::WwwFormUrlDecoder(arg0);
         }
@@ -3891,7 +3890,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           Platform::String^ result;
           result = wrapper->_instance->GetFirstValueByName(arg0);
@@ -4653,7 +4652,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           ::Platform::Object^ result;
           result = wrapper->_instance->GetActivationFactory(arg0);
@@ -5981,7 +5980,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
               return value->IsString();
             },
             [](Local<Value> value) -> ::Platform::String^ {
-              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(value)));
+              return ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), value)));
             }
           ));
           info.GetReturnValue().Set(resObj);
@@ -6520,7 +6519,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           winRtInstance = ref new ::Windows::Foundation::Uri(arg0);
         }
@@ -6536,8 +6535,8 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
-          Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[1])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
+          Platform::String^ arg1 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[1])));
           
           winRtInstance = ref new ::Windows::Foundation::Uri(arg0,arg1);
         }
@@ -6639,7 +6638,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           ::Windows::Foundation::Uri^ result;
           result = wrapper->_instance->CombineUri(arg0);
@@ -6701,7 +6700,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           Platform::String^ result;
           result = ::Windows::Foundation::Uri::UnescapeComponent(arg0);
@@ -6729,7 +6728,7 @@ namespace NodeRT { namespace Windows { namespace Foundation {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           Platform::String^ result;
           result = ::Windows::Foundation::Uri::EscapeComponent(arg0);

--- a/uwp/windows.storage.streams/CollectionsWrap.h
+++ b/uwp/windows.storage.streams/CollectionsWrap.h
@@ -20,7 +20,6 @@ namespace NodeRT {
 	namespace Collections {
 
 		using v8::String;
-		using v8::Handle;
 		using v8::Value;
 		using v8::Boolean;
 		using v8::Integer;
@@ -613,7 +612,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1033,7 +1032,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						T value = wrapper->_convertToTypeFunc(info[1]);
 						wrapper->_instance->InsertAt(index, value);
@@ -1067,7 +1066,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						wrapper->_instance->RemoveAt(index);
 						return;
@@ -1164,7 +1163,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{
@@ -1208,7 +1207,7 @@ namespace NodeRT {
 				{
 					try
 					{
-						unsigned int index = info[0]->Uint32Value();
+						unsigned int index = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
 
 						if (index >= wrapper->_instance->Size)
 						{

--- a/uwp/windows.storage.streams/NodeRtUtils.cpp
+++ b/uwp/windows.storage.streams/NodeRtUtils.cpp
@@ -19,7 +19,6 @@
 namespace NodeRT { namespace Utils {
 
   using v8::String;
-  using v8::Handle;
   using v8::Value;
   using v8::Boolean;
   using v8::Integer;
@@ -143,7 +142,7 @@ namespace NodeRT { namespace Utils {
   // Changes to this code might break the Collection Convertor logic
   ::Platform::String^ V8StringToPlatformString(Local<Value> value)
   {
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
 #ifdef WCHART_NOT_BUILTIN_IN_NODE
     return ref new Platform::String(reinterpret_cast<const wchar_t*>(*stringVal));
 #else
@@ -197,7 +196,7 @@ namespace NodeRT { namespace Utils {
   Local<Value> CreateExternalWinRTObject(const char* ns, const char* objectName, ::Platform::Object ^instance)
   {
     EscapableHandleScope scope;
-    Handle<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
+    Local<Value> opaqueWrapper = CreateOpaqueWrapper(instance);
 
     Local<Object> global = Nan::GetCurrentContext()->Global();
     if (!Nan::Has(global, Nan::New<String>("__winRtNamespaces__").ToLocalChecked()).FromMaybe(false))
@@ -295,7 +294,7 @@ namespace NodeRT { namespace Utils {
     {
       // 116444736000000000 = The time in 100 nanoseconds between 1/1/1970(UTC) to 1/1/1601(UTC)
       // ux_time = (Current time since 1601 in 100 nano sec units)/10000 - 116444736000000000;
-      time.UniversalTime = value->IntegerValue()* 10000 + 116444736000000000;
+      time.UniversalTime = value->IntegerValue(Nan::GetCurrentContext()).FromJust()* 10000 + 116444736000000000;
     }
 
     return time; 
@@ -315,7 +314,7 @@ namespace NodeRT { namespace Utils {
       return false;
     }
 
-    v8::String::Value stringVal(value);
+    v8::String::Value stringVal(v8::Isolate::GetCurrent(), value);
     std::wstring guidStr( L"{" );
     guidStr += StringToWchar(stringVal);
     guidStr += L"}" ;
@@ -650,7 +649,7 @@ namespace NodeRT { namespace Utils {
       return retVal;
     }
 
-    String::Value val(str);
+    String::Value val(v8::Isolate::GetCurrent(), str);
     retVal = (*val)[0];
     return retVal;
   }

--- a/uwp/windows.storage.streams/OpaqueWrapper.h
+++ b/uwp/windows.storage.streams/OpaqueWrapper.h
@@ -31,20 +31,20 @@ namespace NodeRT {
       return _instance;
     }
 
-    static bool IsOpaqueWrapper(v8::Handle<v8::Value> value)
+    static bool IsOpaqueWrapper(v8::Local<v8::Value> value)
     {
       if (value.IsEmpty() || !value->IsObject())
       {
         return false;
       }
 	  
-	  v8::Handle<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
+	  v8::Local<v8::Value> hiddenVal = NodeRT::Utils::GetHiddenValue(value.As<v8::Object>(), Nan::New<v8::String>("__winrtOpaqueWrapper__").ToLocalChecked());
 	  if (hiddenVal.IsEmpty() || !hiddenVal->IsBoolean())
 	  {
 		  return false;
 	  }
 
-	  return hiddenVal->Equals(Nan::True());
+	  return hiddenVal->Equals(Nan::GetCurrentContext(), Nan::True()).FromJust();
     }
 
   private:

--- a/uwp/windows.storage.streams/_nodert_generated.cpp
+++ b/uwp/windows.storage.streams/_nodert_generated.cpp
@@ -35,7 +35,6 @@ const char* REGISTRATION_TOKEN_MAP_PROPERTY_NAME = "__registrationTokenMap__";
 
 using v8::Array;
 using v8::String;
-using v8::Handle;
 using v8::Value;
 using v8::Boolean;
 using v8::Integer;
@@ -3967,7 +3966,7 @@ namespace NodeRT { namespace Windows { namespace Storage { namespace Streams {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           unsigned int result;
           result = wrapper->_instance->WriteString(arg0);
@@ -4002,7 +4001,7 @@ namespace NodeRT { namespace Windows { namespace Storage { namespace Streams {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           unsigned int result;
           result = wrapper->_instance->MeasureString(arg0);
@@ -5158,7 +5157,7 @@ namespace NodeRT { namespace Windows { namespace Storage { namespace Streams {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           unsigned int result;
           result = wrapper->_instance->WriteString(arg0);
@@ -5193,7 +5192,7 @@ namespace NodeRT { namespace Windows { namespace Storage { namespace Streams {
       {
         try
         {
-          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(info[0])));
+          Platform::String^ arg0 = ref new Platform::String(NodeRT::Utils::StringToWchar(v8::String::Value(v8::Isolate::GetCurrent(), info[0])));
           
           unsigned int result;
           result = wrapper->_instance->MeasureString(arg0);

--- a/uwp/windows.storage.streams/node-async.h
+++ b/uwp/windows.storage.streams/node-async.h
@@ -36,7 +36,6 @@ namespace NodeUtils
   using v8::Exception;
   using v8::Object;
   using v8::Local;
-  using v8::Handle;
   using v8::Value;
   using Nan::New;
   using Nan::HandleScope;
@@ -47,7 +46,7 @@ namespace NodeUtils
   using Nan::Persistent;
   using Nan::Undefined;
   
-  typedef std::function<void (int, Handle<Value>*)> InvokeCallbackDelegate;
+  typedef std::function<void (int, Local<Value>*)> InvokeCallbackDelegate;
   
   class Async
   {
@@ -69,7 +68,7 @@ namespace NodeUtils
         callback_args_size = 0;
       }
 
-      void setCallbackArgs(Handle<Value>* argv, int argc)
+      void setCallbackArgs(Local<Value>* argv, int argc)
       {
         HandleScope scope;
 
@@ -117,8 +116,8 @@ namespace NodeUtils
       }
 
       static uv_async_t* NewAsyncToken(
-        Handle<Function> callback, 
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_async_t* asyncHandle = NewAsyncToken();
         SetHandleCallbackData(asyncHandle->data, callback, receiver);
@@ -136,8 +135,8 @@ namespace NodeUtils
       }
 
       static uv_idle_t* NewIdleToken(
-        Handle<Function> callback, 
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         uv_idle_t* idleHandle = NewIdleToken();
         SetHandleCallbackData(idleHandle->data, callback, receiver);
@@ -158,8 +157,8 @@ namespace NodeUtils
 
       static void SetHandleCallbackData(
         void* handleData,
-        Handle<Function> callback, 
-        Handle<Value> receiver)
+        Local<Function> callback,
+        Local<Value> receiver)
       {
         TokenData* Token = static_cast<TokenData*>(handleData);
         Token->callbackData.Reset(CreateCallbackData(callback, receiver));
@@ -176,11 +175,11 @@ namespace NodeUtils
   public:
     template<typename TInput, typename TResult> 
     static void __cdecl Run(
-      std::shared_ptr<TInput> input, 
+      std::shared_ptr<TInput> input,
       std::function<void (Baton<TInput, TResult>*)> doWork, 
       std::function<void (Baton<TInput, TResult>*)> afterWork, 
-      Handle<Function> callback,
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       HandleScope scope;
       Local<Object> callbackData = CreateCallbackData(callback, receiver);
@@ -202,8 +201,8 @@ namespace NodeUtils
     }
 
     static uv_async_t* __cdecl GetAsyncToken(
-      Handle<Function> callback, 
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewAsyncToken(callback, receiver);
     }
@@ -214,8 +213,8 @@ namespace NodeUtils
     }
 
     static uv_idle_t* __cdecl GetIdleToken(
-      Handle<Function> callback, 
-      Handle<Value> receiver = Handle<Value>())
+      Local<Function> callback,
+      Local<Value> receiver = Local<Value>())
     {
       return TokenData::NewIdleToken(callback, receiver);
     }
@@ -239,7 +238,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(async->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -279,7 +278,7 @@ namespace NodeUtils
     {
       TokenData* Token = static_cast<TokenData*>(idler->data);
 
-      InvokeCallbackDelegate invokeCallback = [Token](int argc, Handle<Value>* argv)
+      InvokeCallbackDelegate invokeCallback = [Token](int argc, Local<Value>* argv)
       {
         if (!Token->callbackData.IsEmpty())
         {
@@ -297,12 +296,12 @@ namespace NodeUtils
     }
 
   private:
-    static Handle<Object> CreateCallbackData(Handle<Function> callback, Handle<Value> receiver)
+    static Local<Object> CreateCallbackData(Local<Function> callback, Local<Value> receiver)
     {
       EscapableHandleScope scope;
 
       Local<Object> callbackData;
-      if (!callback.IsEmpty() && !callback->Equals(Undefined()))
+      if (!callback.IsEmpty() && !callback->Equals(Nan::GetCurrentContext(), Undefined()).FromJust())
       {
         callbackData = New<Object>();
         
@@ -317,7 +316,7 @@ namespace NodeUtils
         Local<Value> currentDomain = Undefined();
 
         Local<Object> process = Nan::To<Object>(Nan::Get(GetCurrentContext()->Global(), New<String>("process").ToLocalChecked()).ToLocalChecked()).ToLocalChecked();
-        if (!process->Equals(Undefined()))
+        if (!process->Equals(Nan::GetCurrentContext(), Undefined()).FromJust())
         {
           currentDomain = process->Get(New<String>("domain").ToLocalChecked()) ;
         }
@@ -351,13 +350,13 @@ namespace NodeUtils
       // typical AfterWorkFunc implementation
       //if (baton->error) 
       //{
-      //  Handle<Value> err = Exception::Error(...);
-      //  Handle<Value> argv[] = { err };
+      //  Local<Value> err = Exception::Error(...);
+      //  Local<Value> argv[] = { err };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //}
       //else
       //{
-      //  Handle<Value> argv[] = { Undefined(), ... };
+      //  Local<Value> argv[] = { Undefined(), ... };
       //  baton->setCallbackArgs(argv, _countof(argv));
       //} 
 


### PR DESCRIPTION
The changes are:

- v8::Handle is now called v8::Local.
- A number of functions now require isolates, so we pass in v8::Isolate::GetCurrent()
- A number of functions now require a context, so we pass in Nan::GetCurrentContext()
- A number of functions now return Maybe<T>, so call .FromJust() on those results.